### PR TITLE
Fixed an issue when loading the level2()

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -87,6 +87,7 @@ function level1() {
   addBox(0,170,30,5);
   addExe(10,155,15,15, function() {
     level2();
+    gravity = 0.3;
   }, "green");
 }
 function level2() {

--- a/engine.js
+++ b/engine.js
@@ -186,8 +186,9 @@ function randBot() {
       var dir = colCheck(player,  execute[i]);
       
       if (dir === "r" || dir === "l" || dir === "b" || dir === "t") {
-          execute[i].code();
+          var code = execute[i].code;
           execute.splice(i,1);
+          code();
       }
     }
     


### PR DESCRIPTION
We had an issue when the level2(); or any other level is loaded throught an executable :
When the executable is executed an it loads a new level (with executables), the new level's executable at the same index than the level "anchor" executable will be deleted.
The solution is to delete the executable before executing it, for this I save the function in a temporal variable.
